### PR TITLE
Pull for All Access support

### DIFF
--- a/PlayMusicCL.py
+++ b/PlayMusicCL.py
@@ -13,6 +13,7 @@ from operator import itemgetter
 from getpass import getpass
 import gobject, glib, pygst
 import gst
+import os
 
 m_client = None
 m_player = None
@@ -89,12 +90,12 @@ class gMusicClient(object):
 		if len(urls) > 1:
 			print "Retrieving audio for %s" % (song["title"])
 			audio = self.api.get_stream_audio(song["id"])
-			with open("/tmp/audio.mp3",'wb') as output:
+			cwd = os.getcwd();
+			with open(cwd+"/aa_buffer.mp3",'wb') as output:
 				output.write(audio)
-			return "file:///tmp/audio.mp3"
+			return "file:///"+cwd+"/aa_buffer.mp3"
 		else:
 			return urls[0]
-		return "file:///tmp/audio.mp3"
 
 	def thumbsUp(self, song):
 		try:


### PR DESCRIPTION
These changes add All Access support. Because Google obfuscates AA tracks into multiple URLs with invalid offsets, AA tracks require you to grab the full audio stream (this is handled in the API). These changes stream the URL for non-AA tracks, and pull the mp3 and stream it for AA tracks. There's a slight delay before playing AA tracks due to the download, but it's better than not having support. I may add buffering for AA tracks in a future update.

BTW, awesome tool!
