### PR TITLE
Remove the zero-width non-breaking space at the start of playmusiccl.py

### DIFF
--- a/playmusiccl/playmusiccl.py
+++ b/playmusiccl/playmusiccl.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/python
+#!/usr/bin/python
 # -*- coding: utf_8 -*-
 """
 Command line client for Google Play Music


### PR DESCRIPTION
You can't see it here, but for whatever reason, someone added U+FEFF (zero-width non-breaking space) to the start of this file... this causes most linters to instantly fail on that line.